### PR TITLE
Break reference cycle

### DIFF
--- a/crates/bounce/src/root_state.rs
+++ b/crates/bounce/src/root_state.rs
@@ -94,6 +94,11 @@ impl BounceRootState {
             listener_callbacks: Rc::default(),
         }
     }
+
+    pub fn clear(&self) {
+        self.notion_states.borrow_mut().clear();
+        self.states.borrow_mut().clear();
+    }
 }
 
 impl PartialEq for BounceRootState {

--- a/crates/bounce/src/states/input_selector.rs
+++ b/crates/bounce/src/states/input_selector.rs
@@ -40,7 +40,7 @@ where
     value: Rc<RefCell<Option<Rc<T>>>>,
     listeners: Rc<RefCell<ListenerVec<T>>>,
     state_listener_handles: Rc<RefCell<Vec<Listener>>>,
-    states: Rc<RefCell<Option<Rc<BounceStates>>>>, // reference cycle?
+    states: Rc<RefCell<Option<Rc<BounceStates>>>>,
 }
 
 impl<T> Clone for InputSelectorState<T>


### PR DESCRIPTION
### Description

Partially implements #13.

This pull request consists of the following changes:

- Breaks the reference cycle by draining all states at the time the provider is destroyed.

<!--please provide a list of changes included in this pull request.-->

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [ ] I have added tests for my changes.
- [ ] I have updated docs to reflect any new features / changes in this pull request.
- [ ] I have added my changes to `CHANGELOG.md`.
