### PR TITLE
fix: Race condition when new notion created

### DIFF
--- a/crates/bounce/src/root_state.rs
+++ b/crates/bounce/src/root_state.rs
@@ -76,11 +76,11 @@ impl BounceRootState {
     where
         T: 'static,
     {
-        let notion_states = self.notion_states.borrow();
+        let notion_state = self.notion_states.borrow().get(&TypeId::of::<T>()).cloned();
 
         let notion = notion as Rc<dyn Any>;
 
-        if let Some(m) = notion_states.get(&TypeId::of::<T>()) {
+        if let Some(m) = notion_state {
             for any_state in m.iter() {
                 any_state.apply(notion.clone());
             }


### PR DESCRIPTION
### Description

This pull request consists of the following changes:

Clone `notion_states` when applying a notion. This how it was in v0.2.0 and seems like it got lost in refactoring?

Currently, on `v0.3.0` code that was working on `v0.2.0` panics with following stack trace:

<details>
  <summary>Stack Trace</summary>

```
panicked at 'already borrowed: BorrowMutError', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/bounce-0.3.0/src/root_state.rs:58:60

Stack:

getImports/imports.wbg.__wbg_new_693216e109162396@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7.js:684:21
console_error_panic_hook::Error::new::ha49ec9af7589f04e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[52694]:0xbeaca5
console_error_panic_hook::hook_impl::heef5593d14762556@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[4983]:0x590dec
console_error_panic_hook::hook::h6c496aaa23375f03@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[61665]:0xc65185
core::ops::function::Fn::call::h123cfd7f170d7100@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[47180]:0xb94509
std::panicking::rust_panic_with_hook::h84feca33bd4bd229@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[14332]:0x8116d8
std::panicking::begin_panic_handler::{{closure}}::hd2eacd3bb9ff1eab@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[21452]:0x939f0b
std::sys_common::backtrace::__rust_end_short_backtrace::h976699518d897fb1@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[71714]:0xcc5996
rust_begin_unwind@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[57148]:0xc296be
core::panicking::panic_fmt::hc171d095bc4a492d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[57902]:0xc33b24
core::result::unwrap_failed::h68ab818eb89182b6@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[24717]:0x9a69ea
core::result::Result<T,E>::expect::h63d696e347e87aab@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[17715]:0x8ab5ce
core::cell::RefCell<T>::borrow_mut::h7bf002e59385c374@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[20828]:0x923ba8
bounce::root_state::BounceRootState::get_state::h7f99151b46a42f6f@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[612]:0x24d857
bounce::states::input_selector::use_input_selector_value::{{closure}}::h56a75144902eaa63@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[6872]:0x63b6c8
yew::functional::hooks::use_state::use_state_eq::{{closure}}::h13190c85dbc60cea@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[15696]:0x853287
yew::functional::hooks::use_reducer::use_reducer_base::{{closure}}::h24d55e4df0336239@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[8824]:0x6cf14d
yew::functional::hooks::use_hook::{{closure}}::hbd47b99fc7c7c4dc@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1909]:0x3d2658
scoped_tls_hkt::ScopedKeyMut<T>::with::{{closure}}::hece77949598b0ce5@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[14972]:0x830ce1
scoped_tls_hkt::ScopedKeyMut<T>::replace::h0f4e7a45a504323d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[7680]:0x67c30d
scoped_tls_hkt::ScopedKeyMut<T>::with::h68fbc7280ee00cc9@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[15167]:0x83a27d
yew::functional::hooks::use_hook::h05c2ce181bb3e2b0@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[2171]:0x4089e5
yew::functional::hooks::use_reducer::use_reducer_base::heba7247273a3db2b@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[18309]:0x8c4320
yew::functional::hooks::use_reducer::use_reducer_eq::hb239a3237478e890@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[18308]:0x8c4281
yew::functional::hooks::use_state::use_state_eq::h064ee44cd0c6386d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[6995]:0x645708
bounce::states::input_selector::use_input_selector_value::hd4c1e2af62a53c4d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[2156]:0x405c31
bounce::query::mutation::use_mutation_value::h24ce079d68aa0f14@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[6893]:0x63d35a
<webui::components::group_list::group_list as yew::functional::FunctionProvider>::run::hc1d649ec5ca39c9e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[271]:0x15bd64
<yew::functional::FunctionComponent<T> as yew::html::component::Component>::view::{{closure}}::h93e3cd81d26ae7d5@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[45489]:0xb791ac
scoped_tls_hkt::ScopedKeyMut<T>::set::{{closure}}::ha1abacd820faaab0@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[52591]:0xbe9391
scoped_tls_hkt::ScopedKeyMut<T>::replace::hc8f6784df9eb46ba@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[14444]:0x8170f8
scoped_tls_hkt::ScopedKeyMut<T>::set::he07ab51244b7e5c6@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[31202]:0xa5715c
yew::functional::FunctionComponent<T>::with_hook_state::h4bae1d4a7e49b6df@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[14356]:0x812a21
<yew::functional::FunctionComponent<T> as yew::html::component::Component>::view::h0ac87c8bd0f80a85@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[32469]:0xa75dba
<yew::html::component::lifecycle::RenderRunner<COMP> as yew::scheduler::Runnable>::run::hcc9c2b915ffb06e4@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[899]:0x2c0abc
yew::scheduler::start::{{closure}}::h1e9f14a50447b5c6@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1964]:0x3de003
std::thread::local::LocalKey<T>::try_with::hda46617c7be55e75@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[10958]:0x756e80
std::thread::local::LocalKey<T>::with::hbbd4fe77100b423c@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[30831]:0xa4dd38
yew::scheduler::start::h4e51a1df8ea83d74@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[71767]:0xcc5e22
yew::html::component::scope::Scope<COMP>::push_update::h61ebc5dfa8577a67@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[10983]:0x758530
yew::html::component::scope::Scope<COMP>::send_message::hb2852c741278883e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[20663]:0x91ddc8
<yew::functional::FunctionComponent<T> as yew::html::component::Component>::create::{{closure}}::h7b13ea75e8cf0350@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[25749]:0x9c4d92
yew::functional::HookUpdater::callback::hcb3872a76eab663b@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[3709]:0x4ff74e
yew::functional::hooks::use_reducer::use_reducer_base::{{closure}}::{{closure}}::h83f78a494f8accbd@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[26052]:0x9cdb83
yew::functional::hooks::use_reducer::UseReducerHandle<T>::dispatch::h718edcc749d7725a@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[16061]:0x863e43
yew::functional::hooks::use_state::UseStateHandle<T>::set::h54822b6f3e7054f1@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[52483]:0xbe796d
bounce::states::input_selector::use_input_selector_value::{{closure}}::{{closure}}::ha85c91a2f7bfc2f6@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[52523]:0xbe8312
yew::callback::Callback<IN>::emit::h54b1999b5520d3b0@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[4867]:0x584ba3
bounce::utils::notify_listeners::h57dddb46aac2586c@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[746]:0x287adc
bounce::states::input_selector::InputSelectorState<T>::notify_listeners::h5a091edb923d15fb@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[38910]:0xb00912
bounce::states::input_selector::InputSelectorState<T>::refresh::h693d59bc8fbe0653@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[972]:0x2da67a
bounce::states::input_selector::InputSelectorState<T>::select_value::{{closure}}::h5191e92310be8d08@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[41246]:0xb2d0f9
yew::callback::Callback<IN>::emit::hf0e9fe0ce9409c09@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[5412]:0x5bbbc6
bounce::root_state::BounceStates::get_slice_value::{{closure}}::hbf5c16f93cde4962@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[30350]:0xa4214d
yew::callback::Callback<IN>::emit::h65105560ab8f1a36@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[4868]:0x584d65
bounce::utils::notify_listeners::h801b0b9688bede70@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[749]:0x288e29
bounce::states::slice::SliceState<T>::notify_listeners::hf927f457daab4267@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[26458]:0x9d97df
<bounce::states::slice::SliceState<T> as bounce::any_state::AnyState>::apply::h1113b9954ec9e65f@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[2392]:0x432959
bounce::root_state::BounceRootState::apply_notion::h7d6cc0494eaa9add@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[2496]:0x445e06
bounce::states::future_notion::use_future_notion_runner::{{closure}}::{{closure}}::hea87e18a117e3eee@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[590]:0x242d07
<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h3d936ed3d9058fa8@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[15808]:0x85842f
wasm_bindgen_futures::task::singlethread::Task::run::h19d41b80f6a80342@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[3546]:0x4ea46a
wasm_bindgen_futures::queue::QueueState::run_all::hc42d2df146d88030@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[2635]:0x45e966
wasm_bindgen_futures::queue::Queue::new::{{closure}}::h81e1122a4df121b3@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[30852]:0xa4e5b5
<dyn core::ops::function::FnMut<(A,)>+Output = R as wasm_bindgen::closure::WasmClosure>::describe::invoke::h2f0f59d65273821e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[13770]:0x7f5131
__wbg_adapter_39@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7.js:262:10
real@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7.js:228:20
promise callback*getImports/imports.wbg.__wbg_then_18da6e5453572fc8@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7.js:1032:37
js_sys::Promise::then::h41677963cda5bf17@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[29779]:0xa33737
wasm_bindgen_futures::queue::Queue::schedule_task::hb6611f31d39a9b8d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[6636]:0x628695
wasm_bindgen_futures::queue::Queue::push_task::hd3d0fcba648fdd4d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[52700]:0xbeae39
wasm_bindgen_futures::task::singlethread::Task::wake_by_ref::{{closure}}::h2d076a185799f58e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[42295]:0xb40ce6
std::thread::local::LocalKey<T>::try_with::h89228a367f51fd40@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[10456]:0x73971b
std::thread::local::LocalKey<T>::with::h4476390b97da7795@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[28547]:0xa1376a
wasm_bindgen_futures::task::singlethread::Task::wake_by_ref::h703eb36081e02274@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[17077]:0x88ff7c
wasm_bindgen_futures::task::singlethread::Task::into_raw_waker::raw_wake::hbbecd2c13a9ad09e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[29756]:0xa32dad
core::task::wake::Waker::wake::h71c7a8b8547b075c@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[35955]:0xac4217
<wasm_bindgen_futures::JsFuture as core::convert::From<js_sys::Promise>>::from::finish::hf7c4ec0b61823ba2@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1851]:0x3c62cb
<wasm_bindgen_futures::JsFuture as core::convert::From<js_sys::Promise>>::from::{{closure}}::hf3c5927074d5ee9e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[24481]:0x99f5b7
core::ops::function::FnOnce::call_once::h96a98a949b83cb42@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[29110]:0xa2249b
<T as wasm_bindgen::closure::WasmClosureFnOnce<A,R>>::into_fn_mut::{{closure}}::h7fb1bcde18e18f98@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[27823]:0x9ffe1d
<dyn core::ops::function::FnMut<(A,)>+Output = R as wasm_bindgen::closure::WasmClosure>::describe::invoke::h2f0f59d65273821e@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[13770]:0x7f5131
__wbg_adapter_39@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7.js:262:10
real@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7.js:228:20
promise callback*getImports/imports.wbg.__wbg_then_e5489f796341454b@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7.js:1036:37
js_sys::Promise::then2::h113b718f534dbb49@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[24489]:0x99f9b3
<wasm_bindgen_futures::JsFuture as core::convert::From<js_sys::Promise>>::from::h105bb954f33c929d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[953]:0x2d3c93
<wasm_streams::readable::into_stream::IntoStream as futures_core::stream::Stream>::poll_next::h329b8be037f6b1ae@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1702]:0x3a439f
<S as futures_core::stream::TryStream>::try_poll_next::h7b62ed404bf901dc@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[35120]:0xab1ba8
<futures_util::stream::try_stream::into_stream::IntoStream<St> as futures_core::stream::Stream>::poll_next::h976f5a3ca806a4f9@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[32169]:0xa6eaa5
<futures_util::stream::stream::map::Map<St,F> as futures_core::stream::Stream>::poll_next::h46a43091b7c7a405@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[4933]:0x58bbe7
<futures_util::stream::try_stream::MapOk<St,F> as futures_core::stream::Stream>::poll_next::hd434abd1af1afe64@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[44857]:0xb6e11f
<S as futures_core::stream::TryStream>::try_poll_next::h410d90023d31e85f@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[51473]:0xbd7c85
<futures_util::stream::try_stream::into_stream::IntoStream<St> as futures_core::stream::Stream>::poll_next::h0e6f2832070162d8@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[44863]:0xb6e2c6
<futures_util::stream::stream::map::Map<St,F> as futures_core::stream::Stream>::poll_next::hb35e1d3947c2a172@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[2937]:0x490d3d
<futures_util::stream::try_stream::MapErr<St,F> as futures_core::stream::Stream>::poll_next::h8386fa25ffd1aeec@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[44858]:0xb6e166
<grpc_web_client::ReadableStreamBody as http_body::Body>::poll_data::h9c6edc673314e9f7@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[17395]:0x89db6e
grpc_web_client::call::GrpcWebCall<B>::poll_decode::h7c82ef4bf1e7d936@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[355]:0x1b1423
<grpc_web_client::call::GrpcWebCall<B> as http_body::Body>::poll_data::hefb42092c16e1146@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[24313]:0x99a19a
<http_body::combinators::box_body::UnsyncBoxBody<D,E> as http_body::Body>::poll_data::hd651f2641babc626@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[17396]:0x89dc20
<http_body::combinators::map_err::MapErr<B,F> as http_body::Body>::poll_data::h5f9b306ff3408a6f@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1072]:0x2fb0d9
<http_body::combinators::box_body::UnsyncBoxBody<D,E> as http_body::Body>::poll_data::hd651f2641babc626@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[17396]:0x89dc20
<http_body::combinators::map_data::MapData<B,F> as http_body::Body>::poll_data::h02d2911fd590e16d@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1036]:0x2ef8e4
<http_body::combinators::map_err::MapErr<B,F> as http_body::Body>::poll_data::hc86f8a7ebabd9e02@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1079]:0x2fd3c5
<http_body::combinators::box_body::UnsyncBoxBody<D,E> as http_body::Body>::poll_data::hd651f2641babc626@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[17396]:0x89dc20
<tonic::codec::decode::Streaming<T> as futures_core::stream::Stream>::poll_next::h494aab25fcfcab73@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[161]:0x9862f
tonic::codec::decode::Streaming<T>::message::{{closure}}::{{closure}}::h99030203f38610cd@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[29886]:0xa363f5
<futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll::h7e101364509fecd4@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[30368]:0xa42874
tonic::codec::decode::Streaming<T>::message::{{closure}}::hfa2e81613ba8f8de@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[1189]:0x31e62d
<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hb0af276daea41d84@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[9334]:0x6f249e
tonic::codec::decode::Streaming<T>::trailers::{{closure}}::hdf46cc28a4f917f0@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[270]:0x15aac3
<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hf4a1ea9c1e949f45@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[8091]:0x69af5c
tonic::client::grpc::Grpc<T>::client_streaming::{{closure}}::hf124e996e6b9186c@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[206]:0xfce56
<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h845fee34c15c1efc@http://127.0.0.1:4455/ui/webui-3c9c4549eb51aeb7_bg.wasm:wasm-function[8061]:0x698b9a
```
</details>

I've tested this change on my project. I would appreceate if this this fix gets backported to `0.3.x` and released as `0.3.1`.

Closes #39 

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [ ] I have added tests for my changes.
- [ ] I have updated docs to reflect any new features / changes in this pull request.
- [ ] I have added my changes to `CHANGELOG.md`.
