### PR TITLE
Fix Query Refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Release 0.5.1
+## Release 0.6.0
+
+### Breaking Changes
+
+- `use_mutation_value` is renamed to `use_mutation`.
+- `.result()` on now returns `Option<&...>`.
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Release 0.5.1
+
+### Other Changes
+
+- Fixed query hooks wrongly fallback when refreshing.
+- Fixed query hooks panicking when already fetching.
+
 ## Release 0.5.0
 
 ### Other Changes

--- a/book-src/README.md
+++ b/book-src/README.md
@@ -58,9 +58,7 @@ be notified.
 
 ## Installation
 
-If you have [`cargo-edit`](https://github.com/killercup/cargo-edit)
-installed,
-you can add it to your project with the following command:
+You can add it to your project with the following command:
 
 ```shell
 cargo add bounce
@@ -69,7 +67,7 @@ cargo add bounce
 You can also add it to the `Cargo.toml` of your project manually:
 
 ```toml
-bounce = "0.4"
+bounce = "0.6"
 ```
 
 ## Getting Started

--- a/book-src/core-api.md
+++ b/book-src/core-api.md
@@ -60,10 +60,10 @@ to create a read-only or write-only connection.
 
 **API Reference:**
 
-- [`use_atom`](https://docs.rs/bounce/0.3.0/bounce/fn.use_atom.html)
-- [`use_atom_value`](https://docs.rs/bounce/0.3.0/bounce/fn.use_atom_value.html)
-- [`use_atom_setter`](https://docs.rs/bounce/0.3.0/bounce/fn.use_atom_setter.html)
-- [`#[derive(Atom)]`](https://docs.rs/bounce/0.3.0/bounce/derive.Atom.html)
+- [`use_atom`](https://docs.rs/bounce/latest/bounce/fn.use_atom.html)
+- [`use_atom_value`](https://docs.rs/bounce/latest/bounce/fn.use_atom_value.html)
+- [`use_atom_setter`](https://docs.rs/bounce/latest/bounce/fn.use_atom_setter.html)
+- [`#[derive(Atom)]`](https://docs.rs/bounce/latest/bounce/derive.Atom.html)
 
 
 ### Slice
@@ -143,10 +143,10 @@ html! {
 
 **API Reference:**
 
-- [`use_slice`](https://docs.rs/bounce/0.3.0/bounce/fn.use_slice.html)
-- [`use_slice_value`](https://docs.rs/bounce/0.3.0/bounce/fn.use_slice_value.html)
-- [`use_slice_dispatch`](https://docs.rs/bounce/0.3.0/bounce/fn.use_slice_dispatch.html)
-- [`#[derive(Slice)]`](https://docs.rs/bounce/0.3.0/bounce/derive.Slice.html)
+- [`use_slice`](https://docs.rs/bounce/latest/bounce/fn.use_slice.html)
+- [`use_slice_value`](https://docs.rs/bounce/latest/bounce/fn.use_slice_value.html)
+- [`use_slice_dispatch`](https://docs.rs/bounce/latest/bounce/fn.use_slice_dispatch.html)
+- [`#[derive(Slice)]`](https://docs.rs/bounce/latest/bounce/derive.Slice.html)
 
 ### Selector
 
@@ -184,8 +184,8 @@ impl Selector for IsEven {
 
 API Reference:
 
-- [`Selector`](https://docs.rs/bounce/0.3.0/bounce/trait.Selector.html)
-- [`use_selector_value`](https://docs.rs/bounce/0.3.0/bounce/fn.use_selector_value.html)
+- [`Selector`](https://docs.rs/bounce/latest/bounce/trait.Selector.html)
+- [`use_selector_value`](https://docs.rs/bounce/latest/bounce/fn.use_selector_value.html)
 
 ### Input Selector
 
@@ -196,8 +196,8 @@ An input selector will refresh its value upon either the input or the selected s
 
 API Reference:
 
-- [`InputSelector`](https://docs.rs/bounce/0.3.0/bounce/trait.InputSelector.html)
-- [`use_input_selector_value`](https://docs.rs/bounce/0.3.0/bounce/fn.use_input_selector_value.html)
+- [`InputSelector`](https://docs.rs/bounce/latest/bounce/trait.InputSelector.html)
+- [`use_input_selector_value`](https://docs.rs/bounce/latest/bounce/fn.use_input_selector_value.html)
 
 ### Notion
 
@@ -258,8 +258,8 @@ reset_everything(Reset);
 
 API Reference:
 
-- [`WithNotion`](https://docs.rs/bounce/0.3.0/bounce/trait.WithNotion.html)
-- [`use_notion_applier`](https://docs.rs/bounce/0.3.0/bounce/fn.use_notion_applier.html)
+- [`WithNotion`](https://docs.rs/bounce/latest/bounce/trait.WithNotion.html)
+- [`use_notion_applier`](https://docs.rs/bounce/latest/bounce/fn.use_notion_applier.html)
 
 ### Future Notion
 
@@ -312,9 +312,9 @@ load_user(1);
 
 API Reference:
 
-- [`#[future_notion]`](https://docs.rs/bounce/0.3.0/bounce/attr.future_notion.html)
-- [`Deferred`](https://docs.rs/bounce/0.3.0/bounce/enum.Deferred.html)
-- [`use_future_notion_runner`](https://docs.rs/bounce/0.3.0/bounce/fn.use_future_notion_runner.html)
+- [`#[future_notion]`](https://docs.rs/bounce/latest/bounce/attr.future_notion.html)
+- [`Deferred`](https://docs.rs/bounce/latest/bounce/enum.Deferred.html)
+- [`use_future_notion_runner`](https://docs.rs/bounce/latest/bounce/fn.use_future_notion_runner.html)
 
 #### Note
 
@@ -334,8 +334,8 @@ This API is useful when declaring global side effects (e.g.: document title).
 
 API Reference:
 
-- [`Artifact`](https://docs.rs/bounce/0.3.0/bounce/type.Artifact.html)
-- [`use_artifacts`](https://docs.rs/bounce/0.3.0/bounce/fn.use_artifacts.html)
+- [`Artifact`](https://docs.rs/bounce/latest/bounce/type.Artifact.html)
+- [`use_artifacts`](https://docs.rs/bounce/latest/bounce/fn.use_artifacts.html)
 
 #### Note
 

--- a/book-src/helmet-api.md
+++ b/book-src/helmet-api.md
@@ -48,4 +48,4 @@ the title before it is passed to the document.
 
 ### API Reference:
 
-- [`Helmet API`](https://docs.rs/bounce/0.3.0/bounce/helmet/index.html)
+- [`Helmet API`](https://docs.rs/bounce/latest/bounce/helmet/index.html)

--- a/book-src/query-api.md
+++ b/book-src/query-api.md
@@ -21,7 +21,7 @@ If your endpoint modifies data, you need to use a [mutation](#mutation).
 
 API Reference:
 
-- [`use_query_value`](https://docs.rs/bounce/0.2.0/bounce/query/fn.use_query_value.html)
+- [`use_query_value`](https://docs.rs/bounce/latest/bounce/query/fn.use_query_value.html)
 
 ### Mutation
 
@@ -32,4 +32,4 @@ Mutations are usually used to modify data on the server.
 
 API Reference:
 
-- [`use_mutation_value`](https://docs.rs/bounce/0.2.0/bounce/query/fn.use_mutation_value.html)
+- [`use_mutation`](https://docs.rs/bounce/latest/bounce/query/fn.use_mutation.html)

--- a/crates/bounce-macros/Cargo.toml
+++ b/crates/bounce-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounce-macros"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/bounce-rs/bounce"
 authors = [

--- a/crates/bounce-macros/Cargo.toml
+++ b/crates/bounce-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounce-macros"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 repository = "https://github.com/bounce-rs/bounce"
 authors = [

--- a/crates/bounce/Cargo.toml
+++ b/crates/bounce/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = { version = "0.1.59", optional = true }
 gloo = { version = "0.8.0", features = ["futures"], optional = true }
 html-escape = { version = "0.2.12", optional = true }
 serde = { version = "1.0.148", features = ["derive"] }
+tracing = "0.1"
 
 [dependencies.web-sys]
 version = "0.3.60"

--- a/crates/bounce/Cargo.toml
+++ b/crates/bounce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounce"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/bounce-rs/bounce"
 authors = [
@@ -19,7 +19,7 @@ anymap2 = "0.13.0"
 once_cell = "1.16.0"
 wasm-bindgen = "0.2.83"
 yew = "0.20"
-bounce-macros = { path = "../bounce-macros", version = "0.5.1" }
+bounce-macros = { path = "../bounce-macros", version = "0.6.0" }
 futures = "0.3.25"
 
 async-trait = { version = "0.1.59", optional = true }

--- a/crates/bounce/Cargo.toml
+++ b/crates/bounce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounce"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 repository = "https://github.com/bounce-rs/bounce"
 authors = [
@@ -19,7 +19,7 @@ anymap2 = "0.13.0"
 once_cell = "1.16.0"
 wasm-bindgen = "0.2.83"
 yew = "0.20"
-bounce-macros = { path = "../bounce-macros", version = "0.5.0" }
+bounce-macros = { path = "../bounce-macros", version = "0.5.1" }
 futures = "0.3.25"
 
 async-trait = { version = "0.1.59", optional = true }

--- a/crates/bounce/src/query/mod.rs
+++ b/crates/bounce/src/query/mod.rs
@@ -20,14 +20,14 @@ mod mutation_states;
 mod query_states;
 mod status;
 mod traits;
-mod use_mutation_value;
+mod use_mutation;
 mod use_prepared_query;
 mod use_query;
 mod use_query_value;
 
 pub use status::QueryStatus;
 pub use traits::{Mutation, MutationResult, Query, QueryResult};
-pub use use_mutation_value::{use_mutation_value, UseMutationValueHandle};
+pub use use_mutation::{use_mutation, UseMutationHandle};
 pub use use_prepared_query::use_prepared_query;
 pub use use_query::{use_query, UseQueryHandle};
 pub use use_query_value::{use_query_value, UseQueryValueHandle};

--- a/crates/bounce/src/query/mutation_states.rs
+++ b/crates/bounce/src/query/mutation_states.rs
@@ -130,7 +130,7 @@ where
     T: Mutation + 'static,
 {
     fn apply(mut self: Rc<Self>, notion: Rc<Deferred<RunMutation<T>>>) -> Rc<Self> {
-        match *notion {
+        match notion.as_ref() {
             Deferred::Completed {
                 ref input,
                 ref output,
@@ -148,11 +148,11 @@ where
                             Some(ref n) => {
                                 // only replace if new id is higher.
                                 if n.0 <= input.mutation_id {
-                                    *m = Some((input.mutation_id, (**output).clone()));
+                                    *m = Some((input.mutation_id, output.as_ref().clone()));
                                 }
                             }
                             None => {
-                                *m = Some((input.mutation_id, (**output).clone()));
+                                *m = Some((input.mutation_id, output.as_ref().clone()));
                             }
                         }
                     }

--- a/crates/bounce/src/query/mutation_states.rs
+++ b/crates/bounce/src/query/mutation_states.rs
@@ -24,7 +24,7 @@ pub(super) struct MutationId(Id);
 
 pub(super) struct RunMutationInput<T>
 where
-    T: Mutation + 'static,
+    T: Mutation,
 {
     pub handle_id: HandleId,
     pub mutation_id: MutationId,

--- a/crates/bounce/src/query/query_states.rs
+++ b/crates/bounce/src/query/query_states.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -24,6 +25,7 @@ where
     pub id: Id,
     pub input: Rc<T::Input>,
     pub sender: RunQuerySender<T>,
+    pub is_refresh: bool,
 }
 
 impl<T> Clone for RunQueryInput<T>
@@ -35,6 +37,7 @@ where
             id: self.id,
             input: self.input.clone(),
             sender: self.sender.clone(),
+            is_refresh: self.is_refresh,
         }
     }
 }
@@ -87,12 +90,17 @@ pub(super) async fn run_query<T>(
 where
     T: Query + 'static,
 {
-    let RunQueryInput { id, input, sender } = input.clone();
+    let RunQueryInput {
+        id,
+        input,
+        sender,
+        is_refresh,
+    } = input.clone();
 
     let is_current_query =
         states.get_input_selector_value::<IsCurrentQuery<T>>((id, input.clone()).into());
 
-    if !is_current_query.inner {
+    if !is_current_query.inner && !is_refresh {
         // We drop the channel.
         sender.borrow_mut().take();
 
@@ -155,7 +163,6 @@ where
     T: Query + 'static,
 {
     Refresh {
-        id: Id,
         input: Rc<T::Input>,
     },
     LoadPrepared {
@@ -183,12 +190,15 @@ where
 
     fn reduce(mut self: Rc<Self>, action: Self::Action) -> Rc<Self> {
         match action {
-            Self::Action::Refresh { id, input } => {
-                if self.queries.get(&input).map(|m| m.id()) == Some(id) {
-                    let this = Rc::make_mut(&mut self);
-                    this.ctr += 1;
+            Self::Action::Refresh { input, .. } => {
+                let this = Rc::make_mut(&mut self);
+                this.ctr += 1;
 
-                    this.queries.remove(&input);
+                // Make the query as outdated.
+                if let Some(m) = this.queries.get_mut(&input) {
+                    if let QueryStateValue::Completed { id, result } = m.clone() {
+                        *m = QueryStateValue::Outdated { id, result }
+                    }
                 }
             }
 
@@ -197,8 +207,9 @@ where
                     let this = Rc::make_mut(&mut self);
                     this.ctr += 1;
 
-                    this.queries
-                        .insert(input, QueryStateValue::Completed { id, result });
+                    if let Entry::Vacant(m) = this.queries.entry(input) {
+                        m.insert(QueryStateValue::Completed { id, result });
+                    }
                 }
             }
         }
@@ -277,27 +288,7 @@ where
                     );
                 }
             }
-            Deferred::Outdated { ref input } => {
-                let RunQueryInput { input, id, .. } = (**input).clone();
-                if let Some(QueryStateValue::Completed {
-                    id: current_id,
-                    result: current_result,
-                }) = self.queries.get(&input).cloned()
-                {
-                    if current_id == id {
-                        let this = Rc::make_mut(&mut self);
-                        this.ctr += 1;
-
-                        this.queries.insert(
-                            input.clone(),
-                            QueryStateValue::Outdated {
-                                id,
-                                result: current_result,
-                            },
-                        );
-                    }
-                }
-            }
+            Deferred::Outdated { .. } => {}
         }
 
         self

--- a/crates/bounce/src/query/use_mutation.rs
+++ b/crates/bounce/src/query/use_mutation.rs
@@ -16,8 +16,8 @@ use super::mutation_states::{
     RunMutationInput,
 };
 
-/// A handle returned by [`use_mutation_value`].
-pub struct UseMutationValueHandle<T>
+/// A handle returned by [`use_mutation`].
+pub struct UseMutationHandle<T>
 where
     T: Mutation + 'static,
 {
@@ -27,7 +27,7 @@ where
     _marker: PhantomData<T>,
 }
 
-impl<T> UseMutationValueHandle<T>
+impl<T> UseMutationHandle<T>
 where
     T: Mutation + 'static,
 {
@@ -46,8 +46,8 @@ where
     /// - `None` indicates that a mutation is currently loading or has yet to start(idling).
     /// - `Some(Ok(m))` indicates that the last mutation is successful and the content is stored in `m`.
     /// - `Some(Err(e))` indicates that the last mutation has failed and the error is stored in `e`.
-    pub fn result(&self) -> Option<MutationResult<T>> {
-        self.state.value.clone().flatten()
+    pub fn result(&self) -> Option<&MutationResult<T>> {
+        self.state.value.as_ref().and_then(|m| m.as_ref())
     }
 
     /// Runs a mutation with input.
@@ -67,18 +67,18 @@ where
     }
 }
 
-impl<T> fmt::Debug for UseMutationValueHandle<T>
+impl<T> fmt::Debug for UseMutationHandle<T>
 where
     T: Mutation + fmt::Debug + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UseMutationValueHandle")
+        f.debug_struct("UseMutationHandle")
             .field("state", &self.state.value)
             .finish()
     }
 }
 
-impl<T> Clone for UseMutationValueHandle<T>
+impl<T> Clone for UseMutationHandle<T>
 where
     T: Mutation + 'static,
 {
@@ -103,7 +103,7 @@ where
 /// use std::rc::Rc;
 /// use std::convert::Infallible;
 /// use bounce::prelude::*;
-/// use bounce::query::{Mutation, MutationResult, use_mutation_value, QueryStatus};
+/// use bounce::query::{Mutation, MutationResult, use_mutation, QueryStatus};
 /// use yew::prelude::*;
 /// use async_trait::async_trait;
 /// use yew::platform::spawn_local;
@@ -132,7 +132,7 @@ where
 ///
 /// #[function_component(Comp)]
 /// fn comp() -> Html {
-///     let update_user = use_mutation_value::<UpdateUserMutation>();
+///     let update_user = use_mutation::<UpdateUserMutation>();
 ///
 ///     let on_click_update_user = {
 ///         let update_user = update_user.clone();
@@ -163,7 +163,7 @@ where
 /// }
 /// ```
 #[hook]
-pub fn use_mutation_value<T>() -> UseMutationValueHandle<T>
+pub fn use_mutation<T>() -> UseMutationHandle<T>
 where
     T: Mutation + 'static,
 {
@@ -186,7 +186,7 @@ where
         );
     }
 
-    UseMutationValueHandle {
+    UseMutationHandle {
         id,
         state,
         run_mutation,

--- a/crates/bounce/src/query/use_prepared_query.rs
+++ b/crates/bounce/src/query/use_prepared_query.rs
@@ -109,6 +109,7 @@ where
                     id,
                     input: input.clone(),
                     sender: Rc::new(RefCell::new(Some(sender))),
+                    is_refresh: false,
                 });
 
                 if let Ok(m) = receiver.await {
@@ -180,6 +181,7 @@ where
                     id,
                     input: input.clone(),
                     sender: Rc::default(),
+                    is_refresh: false,
                 }),
             },
             (),
@@ -197,6 +199,7 @@ where
                         id: *id,
                         input: input.clone(),
                         sender: Rc::default(),
+                        is_refresh: false,
                     });
                 }
 

--- a/crates/bounce/src/query/use_query.rs
+++ b/crates/bounce/src/query/use_query.rs
@@ -37,7 +37,6 @@ where
     /// The query will be refreshed with the input provided to the hook.
     pub async fn refresh(&self) -> QueryResult<T> {
         (self.dispatch_state)(QueryStateAction::Refresh {
-            id: self.state_id,
             input: self.input.clone(),
         });
 
@@ -49,6 +48,7 @@ where
             id,
             input: self.input.clone(),
             sender: Rc::new(RefCell::new(Some(sender))),
+            is_refresh: true,
         });
 
         receiver.await.unwrap()
@@ -176,6 +176,7 @@ where
                     id,
                     input: input.clone(),
                     sender: Rc::default(),
+                    is_refresh: false,
                 });
             },
             (),
@@ -193,6 +194,7 @@ where
                         id: *id,
                         input: input.clone(),
                         sender: Rc::default(),
+                        is_refresh: false,
                     });
                 }
 

--- a/crates/bounce/src/query/use_query_value.rs
+++ b/crates/bounce/src/query/use_query_value.rs
@@ -48,8 +48,8 @@ where
     /// - `None` indicates that the query is currently loading.
     /// - `Some(Ok(m))` indicates that the query is successful and the content is stored in `m`.
     /// - `Some(Err(e))` indicates that the query has failed and the error is stored in `e`.
-    pub fn result(&self) -> Option<QueryResult<T>> {
-        match self.value.clone() {
+    pub fn result(&self) -> Option<&QueryResult<T>> {
+        match self.value.as_ref() {
             Some(QueryStateValue::Completed { result, .. })
             | Some(QueryStateValue::Outdated { result, .. }) => Some(result),
             _ => None,

--- a/crates/bounce/src/query/use_query_value.rs
+++ b/crates/bounce/src/query/use_query_value.rs
@@ -60,12 +60,9 @@ where
     ///
     /// The query will be refreshed with the input provided to the hook.
     pub async fn refresh(&self) -> QueryResult<T> {
-        if let Some(ref m) = self.value {
-            (self.dispatch_state)(QueryStateAction::Refresh {
-                id: m.id(),
-                input: self.input.clone(),
-            });
-        }
+        (self.dispatch_state)(QueryStateAction::Refresh {
+            input: self.input.clone(),
+        });
 
         let id = Id::new();
 
@@ -75,6 +72,7 @@ where
             id,
             input: self.input.clone(),
             sender: Rc::new(RefCell::new(Some(sender))),
+            is_refresh: true,
         });
 
         receiver.await.unwrap()
@@ -183,6 +181,7 @@ where
                         id: *id,
                         input: input.clone(),
                         sender: Rc::default(),
+                        is_refresh: false,
                     });
                 }
 

--- a/examples/queries-mutations/src/main.rs
+++ b/examples/queries-mutations/src/main.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use async_trait::async_trait;
 use bounce::prelude::*;
 use bounce::query::{
-    use_mutation_value, use_query, use_query_value, Mutation, MutationResult, Query, QueryResult,
+    use_mutation, use_query, use_query_value, Mutation, MutationResult, Query, QueryResult,
     QueryStatus,
 };
 use bounce::BounceRoot;
@@ -129,7 +129,7 @@ fn refresher() -> Html {
 
 #[function_component(Echo)]
 fn echo() -> Html {
-    let echo_state = use_mutation_value::<EchoMutation>();
+    let echo_state = use_mutation::<EchoMutation>();
     let value = use_state_eq(|| "".to_string());
 
     let disabled = echo_state.status() == QueryStatus::Loading;


### PR DESCRIPTION
### Description

<!--Fix #0000-->

This pull request consists of the following changes:

 - `use_mutation_value` is renamed to `use_mutation`.
 - `.result()` on now returns `Option<&...>`.
 - Fixed query hooks wrongly fallback when refreshing.
 - Fixed query hooks panicking when already fetching.

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [ ] I have added tests for my changes.
- [x] I have updated docs to reflect any new features / changes in this pull request.
- [x] I have added my changes to `CHANGELOG.md`.
