### PR TITLE
Add 'property' attribute to <meta> tag deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 0.6.1
+
+### Other Changes
+
+- Added 'property' to the deduplication logic for `<meta>` tags
+
 ## Release 0.6.0
 
 ### Breaking Changes

--- a/crates/bounce/src/helmet/state.rs
+++ b/crates/bounce/src/helmet/state.rs
@@ -416,6 +416,7 @@ pub(super) fn merge_helmet_states(
                             attrs.get("http-equiv").cloned(),
                             attrs.get("scheme").cloned(),
                             attrs.get("charset").cloned(),
+                            attrs.get("property").cloned(),
                         ),
                         tag.clone(),
                     );


### PR DESCRIPTION
### Description

This fixes #62 

This pull request consists of the following changes:

* Add the 'property' attribute to the meta tag deduplication

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [ ] I have added tests for my changes.
- [ ] I have updated docs to reflect any new features / changes in this pull request.
- [x] I have added my changes to `CHANGELOG.md`.

(I couldn't find tests or docs for this particular feature)

However, from a testing perspective I have dropped this branch into my application where I was trying to do OpenGraph metadata with the Helmet feature, and it works perfectly for me there.