### PR TITLE
Initialise a bounce root with defined state values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 0.7.0
+
+### Other Changes
+
+- Added `get_init_states` to `BounceRoot` that can be used to provide initial state values other than using `Default`.
+
 ## Release 0.6.1
 
 ### Other Changes
@@ -82,7 +88,6 @@
 ### Other Changes:
 
 - Update Readme & Cargo.toml
-
 
 ## Release 0.1.0
 

--- a/crates/bounce/src/any_state.rs
+++ b/crates/bounce/src/any_state.rs
@@ -1,6 +1,8 @@
 use std::any::{Any, TypeId};
 use std::rc::Rc;
 
+use anymap2::AnyMap;
+
 /// A common trait for all states.
 pub(crate) trait AnyState {
     /// Applies a notion.
@@ -10,4 +12,9 @@ pub(crate) trait AnyState {
     fn notion_ids(&self) -> Vec<TypeId> {
         Vec::new()
     }
+
+    /// Creates a state from a possible initialise value.
+    fn create(init_states: &mut AnyMap) -> Self
+    where
+        Self: Sized;
 }

--- a/crates/bounce/src/provider.rs
+++ b/crates/bounce/src/provider.rs
@@ -66,7 +66,7 @@ pub fn bounce_root(props: &BounceRootProps) -> Html {
         );
     }
 
-    #[allow(clippy::unused_unit)]
+    #[allow(clippy::unused_unit, clippy::redundant_clone)]
     {
         let _root_state = root_state.clone();
         let _ = use_transitive_state!(

--- a/crates/bounce/src/provider.rs
+++ b/crates/bounce/src/provider.rs
@@ -1,13 +1,22 @@
+use anymap2::AnyMap;
 use yew::prelude::*;
 
 use crate::root_state::BounceRootState;
 
 /// Properties for [`BounceRoot`].
-#[derive(Properties, Debug, PartialEq)]
+#[derive(Properties, Debug, PartialEq, Clone)]
 pub struct BounceRootProps {
     /// Children of a Bounce Root.
     #[prop_or_default]
     pub children: Children,
+
+    /// A callback that retrieves an `AnyMap` that contains initial states.
+    ///
+    /// States not provided will use `Default`.
+    ///
+    /// This only affects [`Atom`](macro@crate::Atom) and [`Slice`](macro@crate::Slice).
+    #[prop_or_default]
+    pub get_init_states: Option<Callback<(), AnyMap>>,
 }
 
 /// A `<BounceRoot />`.
@@ -33,9 +42,16 @@ pub struct BounceRootProps {
 /// ```
 #[function_component(BounceRoot)]
 pub fn bounce_root(props: &BounceRootProps) -> Html {
-    let children = props.children.clone();
+    let BounceRootProps {
+        children,
+        get_init_states,
+    } = props.clone();
 
-    let root_state = (*use_state(BounceRootState::new)).clone();
+    let root_state = (*use_state(move || {
+        let init_states = get_init_states.map(|m| m.emit(())).unwrap_or_default();
+        BounceRootState::new(init_states)
+    }))
+    .clone();
 
     {
         let root_state = root_state.clone();

--- a/crates/bounce/src/provider.rs
+++ b/crates/bounce/src/provider.rs
@@ -53,6 +53,7 @@ pub fn bounce_root(props: &BounceRootProps) -> Html {
     }))
     .clone();
 
+    #[allow(clippy::redundant_clone)]
     {
         let root_state = root_state.clone();
         use_effect_with_deps(

--- a/crates/bounce/src/root_state.rs
+++ b/crates/bounce/src/root_state.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::rc::Rc;
 
 use anymap2::any::CloneAny;
-use anymap2::{Entry, Map};
+use anymap2::{AnyMap, Entry, Map};
 use yew::callback::Callback;
 
 use crate::any_state::AnyState;
@@ -49,11 +49,12 @@ impl BounceRootState {
         T: AnyState + Clone + Default + 'static,
     {
         let mut states = self.states.borrow_mut();
+        let mut init_states = AnyMap::new();
 
         match states.entry::<T>() {
             Entry::Occupied(m) => m.get().clone(),
             Entry::Vacant(m) => {
-                let state = T::default();
+                let state = T::create(&mut init_states);
                 m.insert(state.clone());
 
                 let mut notion_states = self.notion_states.borrow_mut();

--- a/crates/bounce/src/states/atom.rs
+++ b/crates/bounce/src/states/atom.rs
@@ -5,19 +5,34 @@ use std::rc::Rc;
 
 use super::slice::{use_slice, use_slice_dispatch, use_slice_value, Slice, UseSliceHandle};
 
+use anymap2::AnyMap;
 pub use bounce_macros::Atom;
 use yew::prelude::*;
 
 #[doc(hidden)]
 pub trait Atom: PartialEq + Default {
+    /// Applies a notion.
+    ///
+    /// This always yields a new instance of [`Rc<Self>`] so it can be compared with the previous
+    /// atom using [`PartialEq`].
     #[allow(unused_variables)]
     fn apply(self: Rc<Self>, notion: Rc<dyn Any>) -> Rc<Self> {
         self
     }
 
+    /// Returns a list of notion ids that this atom accepts.
     fn notion_ids(&self) -> Vec<TypeId>;
 
+    /// Notifies an atom that its value has changed.
     fn changed(self: Rc<Self>) {}
+
+    /// Creates a new atom with its initial value.
+    fn create(init_states: &mut AnyMap) -> Self
+    where
+        Self: 'static + Sized,
+    {
+        init_states.remove().unwrap_or_default()
+    }
 }
 
 /// A trait to provide cloning on atoms.
@@ -68,6 +83,15 @@ where
 
     fn changed(self: Rc<Self>) {
         self.inner.clone().changed();
+    }
+
+    fn create(init_states: &mut AnyMap) -> Self
+    where
+        Self: 'static + Sized,
+    {
+        Self {
+            inner: T::create(init_states).into(),
+        }
     }
 }
 

--- a/crates/bounce/src/states/input_selector.rs
+++ b/crates/bounce/src/states/input_selector.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
+use anymap2::AnyMap;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -136,13 +137,6 @@ where
 pub(crate) type InputSelectorMap<T> =
     HashMap<Rc<<T as InputSelector>::Input>, InputSelectorState<T>>;
 
-impl<T> AnyState for InputSelectorState<T>
-where
-    T: InputSelector + 'static,
-{
-    fn apply(&self, _notion: Rc<dyn Any>) {}
-}
-
 pub(crate) struct InputSelectorsState<T>
 where
     T: InputSelector + 'static,
@@ -195,6 +189,13 @@ where
     T: InputSelector + 'static,
 {
     fn apply(&self, _notion: Rc<dyn Any>) {}
+
+    fn create(_init_states: &mut AnyMap) -> Self
+    where
+        Self: Sized,
+    {
+        Self::default()
+    }
 }
 
 /// A hook to connect to an [`InputSelector`].

--- a/crates/bounce/src/states/slice.rs
+++ b/crates/bounce/src/states/slice.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::rc::Rc;
 
+use anymap2::AnyMap;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -37,6 +38,14 @@ pub trait Slice: PartialEq + Default {
 
     /// Notifies a slice that it has changed.
     fn changed(self: Rc<Self>) {}
+
+    /// Creates a new Slice with its initial value.
+    fn create(init_states: &mut AnyMap) -> Self
+    where
+        Self: 'static + Sized,
+    {
+        init_states.remove().unwrap_or_default()
+    }
 }
 
 /// A trait to provide cloning on slices.
@@ -136,6 +145,16 @@ where
 
     fn notion_ids(&self) -> Vec<TypeId> {
         self.value.borrow().notion_ids()
+    }
+
+    fn create(init_states: &mut AnyMap) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            value: Rc::new(RefCell::new(T::create(init_states).into())),
+            listeners: Rc::default(),
+        }
     }
 }
 

--- a/crates/bounce/src/states/slice.rs
+++ b/crates/bounce/src/states/slice.rs
@@ -39,7 +39,7 @@ pub trait Slice: PartialEq + Default {
     /// Notifies a slice that it has changed.
     fn changed(self: Rc<Self>) {}
 
-    /// Creates a new Slice with its initial value.
+    /// Creates a new slice with its initial value.
     fn create(init_states: &mut AnyMap) -> Self
     where
         Self: 'static + Sized,

--- a/crates/bounce/tests/init_states.rs
+++ b/crates/bounce/tests/init_states.rs
@@ -23,8 +23,7 @@ async fn get_text_content<S: AsRef<str>>(selector: S) -> String {
 }
 
 #[derive(Atom, PartialEq, Default)]
-struct State
-{
+struct State {
     inner: u32,
 }
 
@@ -63,7 +62,7 @@ async fn test_with_init_states() {
     fn root() -> Html {
         fn get_init_states(_: ()) -> AnyMap {
             let mut map = AnyMap::new();
-            map.insert(State{ inner: 1 });
+            map.insert(State { inner: 1 });
 
             map
         }

--- a/crates/bounce/tests/init_states.rs
+++ b/crates/bounce/tests/init_states.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+use anymap2::AnyMap;
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+use bounce::prelude::*;
+use bounce::BounceRoot;
+use gloo::timers::future::sleep;
+use gloo::utils::document;
+use yew::prelude::*;
+
+async fn get_text_content<S: AsRef<str>>(selector: S) -> String {
+    sleep(Duration::ZERO).await;
+
+    document()
+        .query_selector(selector.as_ref())
+        .unwrap()
+        .unwrap()
+        .text_content()
+        .unwrap()
+}
+
+#[derive(Atom, PartialEq, Default)]
+struct State
+{
+    inner: u32,
+}
+
+#[function_component(Comp)]
+fn comp() -> Html {
+    let a = use_atom_value::<State>();
+
+    html! {
+        <div>
+            <div id="a">{a.inner}</div>
+        </div>
+    }
+}
+
+#[test]
+async fn test_without_init_states() {
+    #[function_component(Root)]
+    fn root() -> Html {
+        html! {
+            <BounceRoot>
+                <Comp />
+            </BounceRoot>
+        }
+    }
+
+    yew::Renderer::<Root>::with_root(document().query_selector("#output").unwrap().unwrap())
+        .render();
+
+    let s = get_text_content("#a").await;
+    assert_eq!(s, "0");
+}
+
+#[test]
+async fn test_with_init_states() {
+    #[function_component(Root)]
+    fn root() -> Html {
+        fn get_init_states(_: ()) -> AnyMap {
+            let mut map = AnyMap::new();
+            map.insert(State{ inner: 1 });
+
+            map
+        }
+
+        html! {
+            <BounceRoot {get_init_states}>
+                <Comp />
+            </BounceRoot>
+        }
+    }
+
+    yew::Renderer::<Root>::with_root(document().query_selector("#output").unwrap().unwrap())
+        .render();
+
+    let s = get_text_content("#a").await;
+    assert_eq!(s, "1");
+}


### PR DESCRIPTION
### Description

Partially fulfils: #56.

This pull request provides a `get_init_states` function that can be used to provide states values that overrides `Default`.

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [x] I have added tests for my changes.
- [x] I have updated docs to reflect any new features / changes in this pull request.
- [x] I have added my changes to `CHANGELOG.md`.
