### PR TITLE
Break loop by returning the inner value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release 0.7.1
+
+- Break loop by returning the inner value.
+
 ## Release 0.7.0
 
 ### Other Changes

--- a/crates/bounce/src/states/atom.rs
+++ b/crates/bounce/src/states/atom.rs
@@ -143,7 +143,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("UseAtomHandle")
-            .field("inner", self)
+            .field("inner", self.inner.inner.as_ref())
             .finish()
     }
 }

--- a/crates/bounce/src/utils.rs
+++ b/crates/bounce/src/utils.rs
@@ -37,7 +37,7 @@ impl Listener {
 
 impl fmt::Debug for Listener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Listener").finish()
+        f.debug_struct("Listener").finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
### Description

Fix #77 

This pull request consists of the following changes:

- Breaks the call loop caused by referencing self in debug implementation.

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [ ] I have added tests for my changes.
- [ ] I have updated docs to reflect any new features / changes in this pull request.
- [x] I have added my changes to `CHANGELOG.md`.
